### PR TITLE
Add log while not using user input

### DIFF
--- a/bin/timedatectl_test.py
+++ b/bin/timedatectl_test.py
@@ -54,13 +54,10 @@ def timedatectl_parser() -> Dict[str, str]:
         LOCAL_TIME: None,
     }
     output = run("timedatectl")
-    timezone_search = re.search(
-        r"Time zone:\s+(\S+)\s+\(.+\)", output
-    )
+    timezone_search = re.search(r"Time zone:\s+(\S+)\s+\(.+\)", output)
     ntp_search = re.search(r"NTP service:\s+(\S+)", output)
-    local_time_search = re.search(
-        r"Local time: \S+ (\d{4}-\d{2}-\d{2})", output
-    )
+    local_time_search = re.search(r"Local time: \S+ (\d{4}-\d{2}-\d{2})",
+                                  output)
     if timezone_search:
         result[TIME_ZONE] = timezone_search.group(1)
     if ntp_search:
@@ -201,6 +198,13 @@ def test_timezone(target_timezone):
         with TimeZoneRestore() as tzr:
             if tzr.restore_timezone in timezone_list:
                 timezone_list.remove(tzr.restore_timezone)
+                if tzr.restore_timezone == target_timezone:
+                    logging.info(
+                        "Current timezone is the same as target timezone %s",
+                        target_timezone,
+                    )
+                    logging.info("Will use default time zone %s",
+                                 timezone_list[-1])
             set_timezone(timezone_list[-1])
     except Exception as e:
         logging.error("Error during timezone test: %s", e)
@@ -210,9 +214,7 @@ def test_timezone(target_timezone):
 def test_ntp():
     mock_date = "2024-02-29"
     with NtpRestore():
-        logging.info(
-            "Attempting to set date to a mockup date %s", mock_date
-        )
+        logging.info("Attempting to set date to a mockup date %s", mock_date)
         timedatectl_set("set-time", mock_date)
         current_date = timedatectl_parser()[LOCAL_TIME]
         logging.info("Current date is %s", current_date)
@@ -246,9 +248,8 @@ class TimeZoneRestore:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        logging.info(
-            "Restoring original timezone to %s", self.restore_timezone
-        )
+        logging.info("Restoring original timezone to %s",
+                     self.restore_timezone)
         set_timezone(self.restore_timezone)
         if exc_type:
             logging.error("An error occurred: %s", exc_value)
@@ -277,14 +278,12 @@ class NtpRestore:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Test system configuration tasks"
-    )
+        description="Test system configuration tasks")
     subparsers = parser.add_subparsers(
         dest="test", required=True, help="Test functions in timezone and ntp"
     )
-    timezone_subparser = subparsers.add_parser(
-        "timezone", help="Run timezone test"
-    )
+    timezone_subparser = subparsers.add_parser("timezone",
+                                               help="Run timezone test")
     timezone_subparser.add_argument(
         "-t",
         "--target",

--- a/bin/timedatectl_test.py
+++ b/bin/timedatectl_test.py
@@ -54,10 +54,11 @@ def timedatectl_parser() -> Dict[str, str]:
         LOCAL_TIME: None,
     }
     output = run("timedatectl")
-    timezone_search = re.search(r"Time zone:\s+(\S+)\s+\(.+\)", output)
+    timezone_search = re.search(r"Time zone: (\S+) \(.+\)", output)
     ntp_search = re.search(r"NTP service:\s+(\S+)", output)
-    local_time_search = re.search(r"Local time: \S+ (\d{4}-\d{2}-\d{2})",
-                                  output)
+    local_time_search = re.search(
+        r"Local time: \S+ (\d{4}-\d{2}-\d{2})", output
+    )
     if timezone_search:
         result[TIME_ZONE] = timezone_search.group(1)
     if ntp_search:
@@ -200,11 +201,10 @@ def test_timezone(target_timezone):
                 timezone_list.remove(tzr.restore_timezone)
                 if tzr.restore_timezone == target_timezone:
                     logging.info(
-                        "Current timezone is the same as target timezone %s",
-                        target_timezone,
+                        "Current timezone is the same as target timezone, "
+                        "so the timezone %s is used instead.",
+                        timezone_list[-1],
                     )
-                    logging.info("Will use default time zone %s",
-                                 timezone_list[-1])
             set_timezone(timezone_list[-1])
     except Exception as e:
         logging.error("Error during timezone test: %s", e)
@@ -248,8 +248,9 @@ class TimeZoneRestore:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        logging.info("Restoring original timezone to %s",
-                     self.restore_timezone)
+        logging.info(
+            "Restoring original timezone to %s", self.restore_timezone
+        )
         set_timezone(self.restore_timezone)
         if exc_type:
             logging.error("An error occurred: %s", exc_value)
@@ -278,12 +279,14 @@ class NtpRestore:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Test system configuration tasks")
+        description="Test system configuration tasks"
+    )
     subparsers = parser.add_subparsers(
         dest="test", required=True, help="Test functions in timezone and ntp"
     )
-    timezone_subparser = subparsers.add_parser("timezone",
-                                               help="Run timezone test")
+    timezone_subparser = subparsers.add_parser(
+        "timezone", help="Run timezone test"
+    )
     timezone_subparser.add_argument(
         "-t",
         "--target",

--- a/tests/test_timedatectl_test.py
+++ b/tests/test_timedatectl_test.py
@@ -1,0 +1,199 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from timedatectl_test import (
+    timedatectl_parser,
+    timedatectl_set,
+    toggle_ntp,
+    set_timezone,
+    run,
+    TIME_ZONE,
+    NTP,
+    LOCAL_TIME,
+)
+
+
+class TestTimeDateCtl(unittest.TestCase):
+    @patch("timedatectl_test.run")
+    def test_timedatectl_parser(self, mock_run):
+        mock_run.return_value = """
+            Local time: 二 2024-06-11 11:28:42 CST
+            Universal time: 二 2024-06-11 03:28:42 UTC
+            RTC time: 二 2024-06-11 03:28:42
+            Time zone: Asia/Taipei (CST, +0800)
+            System clock synchronized: yes
+            NTP service: active
+            RTC in local TZ: no
+        """
+        expected = {
+            TIME_ZONE: "Asia/Taipei",
+            NTP: "active",
+            LOCAL_TIME: "2024-06-11",
+        }
+        result = timedatectl_parser()
+        self.assertEqual(result, expected)
+
+    @patch("timedatectl_test.run")
+    def test_timedatectl_set(self, mock_run):
+        timedatectl_set("set-timezone", "UTC")
+        mock_run.assert_called_with("timedatectl set-timezone UTC")
+
+    @patch("timedatectl_test.timedatectl_set")
+    @patch("timedatectl_test.timedatectl_parser")
+    def test_toggle_ntp_enable_success(
+        self, mock_timedatectl_parser, mock_timedatectl_set
+    ):
+        mock_timedatectl_parser.return_value = {"NTP": "active"}
+
+        # Call the function with status True to enable NTP
+        toggle_ntp(True)
+
+        # Check if the timedatectl_set function was called with the
+        # correct parameters
+        mock_timedatectl_set.assert_called_with("set-ntp", True)
+
+        # Check if the parser was called to verify the state
+        mock_timedatectl_parser.assert_called_once()
+
+    @patch("timedatectl_test.timedatectl_set")
+    @patch("timedatectl_test.timedatectl_parser")
+    def test_toggle_ntp_disable_success(
+        self, mock_timedatectl_parser, mock_timedatectl_set
+    ):
+        mock_timedatectl_parser.return_value = {"NTP": "inactive"}
+
+        # Call the function with status False to disable NTP
+        toggle_ntp(False)
+
+        # Check if the timedatectl_set function was called with the
+        # correct parameters
+        mock_timedatectl_set.assert_called_with("set-ntp", False)
+
+        # Check if the parser was called to verify the state
+        mock_timedatectl_parser.assert_called_once()
+
+    @patch("timedatectl_test.timedatectl_set")
+    @patch("timedatectl_test.timedatectl_parser")
+    def test_toggle_ntp_enable_failure(
+        self, mock_timedatectl_parser, mock_timedatectl_set
+    ):
+        mock_timedatectl_parser.return_value = {"NTP": "inactive"}
+
+        with self.assertRaises(SystemExit):
+            toggle_ntp(True)
+
+        # Check if the timedatectl_set function was called with the
+        # correct parameters
+        mock_timedatectl_set.assert_called_with("set-ntp", True)
+
+        # Check if the parser was called to verify the state
+        mock_timedatectl_parser.assert_called_once()
+
+    @patch("timedatectl_test.timedatectl_set")
+    @patch("timedatectl_test.timedatectl_parser")
+    def test_toggle_ntp_disable_failure(
+        self, mock_timedatectl_parser, mock_timedatectl_set
+    ):
+        mock_timedatectl_parser.return_value = {"NTP": "active"}
+
+        with self.assertRaises(SystemExit):
+            toggle_ntp(False)
+
+        # Check if the timedatectl_set function was called with the
+        # correct parameters
+        mock_timedatectl_set.assert_called_with("set-ntp", False)
+
+        # Check if the parser was called to verify the state
+        mock_timedatectl_parser.assert_called_once()
+
+    @patch("timedatectl_test.timedatectl_set", side_effect=SystemError)
+    def test_toggle_ntp_set_command_failure(self, mock_timedatectl_set):
+        with self.assertRaises(SystemExit):
+            toggle_ntp(True)
+
+        # Check if the timedatectl_set function was called and
+        # raised SystemError
+        mock_timedatectl_set.assert_called_with("set-ntp", True)
+
+    @patch("timedatectl_test.timedatectl_set")
+    @patch("timedatectl_test.timedatectl_parser")
+    def test_set_timezone_success(
+        self, mock_timedatectl_parser, mock_timedatectl_set
+    ):
+        # Mock the return value of timedatectl_parser to match the
+        # desired timezone
+        mock_timedatectl_parser.return_value = {
+            "Time_zone": "America/New_York"
+        }
+        mock_timedatectl_set.retrun_value = True
+        # Call the function with the desired timezone
+        set_timezone("America/New_York")
+
+        # Check if the timedatectl_set function was called with the
+        # correct parameters
+        mock_timedatectl_set.assert_called_with(
+            "set-timezone", "America/New_York"
+        )
+
+        # Check if the parser was called to verify the state
+        mock_timedatectl_parser.assert_called_once()
+
+    @patch("timedatectl_test.timedatectl_set")
+    @patch("timedatectl_test.timedatectl_parser")
+    def test_set_timezone_failure(
+        self, mock_timedatectl_parser, mock_timedatectl_set
+    ):
+        # Mock the return value of timedatectl_parser to not match the
+        # desired timezone
+        mock_timedatectl_parser.return_value = {
+            "Time_zone": "America/Los_Angeles"
+        }
+
+        with self.assertRaises(SystemExit):
+            set_timezone("America/New_York")
+
+        # Check if the timedatectl_set function was called with the
+        # correct parameters
+        mock_timedatectl_set.assert_called_with(
+            "set-timezone", "America/New_York"
+        )
+
+        # Check if the parser was called to verify the state
+        mock_timedatectl_parser.assert_called_once()
+
+    @patch(
+        "timedatectl_test.timedatectl_set",
+        side_effect=SystemError("Failed to set timezone"),
+    )
+    def test_set_timezone_command_failure(self, mock_timedatectl_set):
+        with self.assertRaises(SystemExit):
+            set_timezone("America/New_York")
+
+        # Check if the timedatectl_set function was called and
+        # raised SystemError
+        mock_timedatectl_set.assert_called_with(
+            "set-timezone", "America/New_York"
+        )
+
+    @patch("timedatectl_test.shlex.split")
+    @patch("timedatectl_test.sp.run")
+    def test_run_success(self, mock_run, mock_split):
+        mock_process = MagicMock()
+        mock_process.returncode = 0
+        mock_process.stdout = "success"
+        mock_run.return_value = mock_process
+        result = run("timedatectl status")
+        self.assertEqual(result, "success")
+
+    @patch("timedatectl_test.shlex.split")
+    @patch("timedatectl_test.sp.run")
+    def test_run_failure(self, mock_run, mock_split):
+        mock_process = MagicMock()
+        mock_process.returncode = 1
+        mock_process.stderr = "error"
+        mock_run.return_value = mock_process
+        with self.assertRaises(SystemError):
+            run("timedatectl status")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Add log while using default timezone.

2024-06-12 16:04:05,410 [INFO] Start to test timezone setting up
2024-06-12 16:04:05,639 [INFO] Current timezone is the same as target timezone Asia/Taipei
2024-06-12 16:04:05,639 [INFO] Will use default time zone UTC
2024-06-12 16:04:05,639 [INFO] Attempting to set timezone to UTC
2024-06-12 16:04:05,726 [INFO] Current timezone is UTC
2024-06-12 16:04:05,727 [INFO] Timezone setup succeed!
2024-06-12 16:04:05,727 [INFO] Restoring original timezone to Asia/Taipei
2024-06-12 16:04:05,727 [INFO] Attempting to set timezone to Asia/Taipei
2024-06-12 16:04:05,884 [INFO] Current timezone is Asia/Taipei
2024-06-12 16:04:05,884 [INFO] Timezone setup succeed!

* Add unittest